### PR TITLE
Main bionics balance suggestion

### DIFF
--- a/1.2/Defs/HeDiffDefs/Augments/Tail_Augments/Stiff/HediffDef.xml
+++ b/1.2/Defs/HeDiffDefs/Augments/Tail_Augments/Stiff/HediffDef.xml
@@ -14,8 +14,8 @@
     <stages>
       <li>
         <statOffsets>
-          <ArmorRating_Sharp>0.4</ArmorRating_Sharp>
-          <ArmorRating_Blunt>0.4</ArmorRating_Blunt>
+          <ArmorRating_Sharp>0.2</ArmorRating_Sharp>
+          <ArmorRating_Blunt>0.2</ArmorRating_Blunt>
           <MaxHitPoints>20</MaxHitPoints>
         </statOffsets>
         <capMods>

--- a/1.2/Defs/HeDiffDefs/BionicLimbs/BionicArms/adv/HediffDefs.xml
+++ b/1.2/Defs/HeDiffDefs/BionicLimbs/BionicArms/adv/HediffDefs.xml
@@ -8,14 +8,14 @@
     <spawnThingOnRemoved>AvaliAdvancedBionicArm</spawnThingOnRemoved>
     <addedPartProps>
       <solid>true</solid>
-      <partEfficiency>1.5</partEfficiency>
+      <partEfficiency>1.6</partEfficiency>
       <betterThanNatural>true</betterThanNatural>
     </addedPartProps>
     <stages>
       <li>
         <statOffsets>
-          <ArmorRating_Sharp>1.0</ArmorRating_Sharp>
-          <ArmorRating_Blunt>1.0</ArmorRating_Blunt>
+          <ArmorRating_Sharp>0.1</ArmorRating_Sharp>
+          <ArmorRating_Blunt>0.1</ArmorRating_Blunt>
           <MaxHitPoints>15</MaxHitPoints>
         </statOffsets>
       </li>

--- a/1.2/Defs/HeDiffDefs/BionicLimbs/BionicArms/basic/HediffDefs.xml
+++ b/1.2/Defs/HeDiffDefs/BionicLimbs/BionicArms/basic/HediffDefs.xml
@@ -8,14 +8,14 @@
     <spawnThingOnRemoved>AvaliBasicBionicArm</spawnThingOnRemoved>
     <addedPartProps>
       <solid>true</solid>
-      <partEfficiency>1.05</partEfficiency>
+      <partEfficiency>1.35</partEfficiency>
       <betterThanNatural>true</betterThanNatural>
     </addedPartProps>
     <stages>
       <li>
         <statOffsets>
-          <ArmorRating_Sharp>0.5</ArmorRating_Sharp>
-          <ArmorRating_Blunt>0.5</ArmorRating_Blunt>
+          <ArmorRating_Sharp>0.05</ArmorRating_Sharp>
+          <ArmorRating_Blunt>0.05</ArmorRating_Blunt>
           <MaxHitPoints>5</MaxHitPoints>
         </statOffsets>
       </li>

--- a/1.2/Defs/HeDiffDefs/BionicLimbs/BionicLegs/adv/HediffDefs.xml
+++ b/1.2/Defs/HeDiffDefs/BionicLimbs/BionicLegs/adv/HediffDefs.xml
@@ -8,14 +8,14 @@
     <spawnThingOnRemoved>AvaliAdvancedBionicLeg</spawnThingOnRemoved>
     <addedPartProps>
       <solid>true</solid>
-      <partEfficiency>1.5</partEfficiency>
+      <partEfficiency>1.6</partEfficiency>
       <betterThanNatural>true</betterThanNatural>
     </addedPartProps>
     <stages>
       <li>
         <statOffsets>
-          <ArmorRating_Sharp>1.0</ArmorRating_Sharp>
-          <ArmorRating_Blunt>1.0</ArmorRating_Blunt>
+          <ArmorRating_Sharp>0.10</ArmorRating_Sharp>
+          <ArmorRating_Blunt>0.10</ArmorRating_Blunt>
           <MaxHitPoints>15</MaxHitPoints>
         </statOffsets>
       </li>

--- a/1.2/Defs/HeDiffDefs/BionicLimbs/BionicLegs/basic/HediffDefs.xml
+++ b/1.2/Defs/HeDiffDefs/BionicLimbs/BionicLegs/basic/HediffDefs.xml
@@ -8,15 +8,15 @@
     <spawnThingOnRemoved>AvaliBasicBionicLeg</spawnThingOnRemoved>
     <addedPartProps>
       <solid>true</solid>
-      <partEfficiency>1.05</partEfficiency>
+      <partEfficiency>1.35</partEfficiency>
       <betterThanNatural>true</betterThanNatural>
     </addedPartProps>
     
     <stages>
       <li>
         <statOffsets>
-          <ArmorRating_Sharp>0.5</ArmorRating_Sharp>
-          <ArmorRating_Blunt>0.5</ArmorRating_Blunt>
+          <ArmorRating_Sharp>0.05</ArmorRating_Sharp>
+          <ArmorRating_Blunt>0.05</ArmorRating_Blunt>
           <MaxHitPoints>5</MaxHitPoints>
         </statOffsets>
       </li>

--- a/1.2/Defs/HeDiffDefs/BionicLimbs/BionicTail/adv/HediffDefs.xml
+++ b/1.2/Defs/HeDiffDefs/BionicLimbs/BionicTail/adv/HediffDefs.xml
@@ -15,8 +15,8 @@
     <stages>
       <li>
         <statOffsets>
-          <ArmorRating_Sharp>1.0</ArmorRating_Sharp>
-          <ArmorRating_Blunt>1.0</ArmorRating_Blunt>
+          <ArmorRating_Sharp>0.10</ArmorRating_Sharp>
+          <ArmorRating_Blunt>0.10</ArmorRating_Blunt>
           <MaxHitPoints>15</MaxHitPoints>
         </statOffsets>
       </li>

--- a/1.2/Defs/HeDiffDefs/BionicLimbs/BionicTail/basic/HediffDefs.xml
+++ b/1.2/Defs/HeDiffDefs/BionicLimbs/BionicTail/basic/HediffDefs.xml
@@ -9,14 +9,14 @@
     <hediffClass>HediffWithComps</hediffClass>
     <addedPartProps>
       <solid>true</solid>
-      <partEfficiency>1.05</partEfficiency>
+      <partEfficiency>1.30</partEfficiency>
       <betterThanNatural>true</betterThanNatural>
     </addedPartProps>
     <stages>
       <li>
         <statOffsets>
-          <ArmorRating_Sharp>0.5</ArmorRating_Sharp>
-          <ArmorRating_Blunt>0.5</ArmorRating_Blunt>
+          <ArmorRating_Sharp>0.05</ArmorRating_Sharp>
+          <ArmorRating_Blunt>0.05</ArmorRating_Blunt>
           <MaxHitPoints>5</MaxHitPoints>
         </statOffsets>
       </li>


### PR DESCRIPTION
This PR nerfs the damage resistance given by the prosthetics and buffs their effectiveness to be slightly above RBSE prothesis.

The damage resistances of the limbs apply to the whole body and stack with each other so having just two advanced arms would mean the Avali would have 200% damage resistance on sharp and blunt. Basic bionic legs were also improved on effectiveness so that having both legs improved wouldn't be just a 103% total.

Resource cost and all could still use more tweaking but it is a start.